### PR TITLE
Idempotent stashing

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -29,7 +29,8 @@ class SessionStashable:
             return # nothing to do
         if not session.has_key(self.session_variable):
             session[self.session_variable] = []
-        session[self.session_variable].append(self.pk)
+        if not self.pk in session[self.session_variable]:
+            session[self.session_variable].append(self.pk)
         session.modified = True
         #print "stashed %s in session" % self
         


### PR DESCRIPTION
Hi James

I've been using django_session_stashable quite a bit, and I just had an issue that took me a fair while to diagnose, and which I think is worth saving other people (and future me :-)) from.

At the moment, if you stash a model which is already stashed, it gets stashed again. I can't see any good reason to have it like this - the stash is just as list of ids, so once something is in, it's in. I've changed this branch to only stash model instances that aren't stashed already, which seems like the best thing to do.

Cheers,

Duncan

PS I tried doing this with a set instead of a list, but got errors in places I'd not expect, so I'm sticking with the list!
